### PR TITLE
supports getting subs data in new object format (also supports old wa…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const io = require('socket.io-client');
 const Mustache = require('mustache');
+const _ = require('lodash');
 
 const log = require('../lib/bunyan-api').createLogger('cluster-subscription');
 
@@ -39,8 +40,13 @@ const socket = io(RAZEE_API, {
 socket.connect();
 
 // listen for subscription changes
-socket.on('subscriptions', async function(urls) {
-  log.info('Received subscription data from razeeapi', urls);
+socket.on('subscriptions', async function(data) {
+  log.info('Received subscription data from razeeapi', data);
+
+  var urls = data.urls;
+  if(_.isArray(data)){
+    urls = data;
+  }
 
   const resourceTemplate = {
     'apiVersion': API_VERSION,


### PR DESCRIPTION
Old way sends an array of urls:
```js
[ 'api/v1/channels/bbbbb/1c9a1e5b-742c-40a2-bdd8-3773a9711f18' ]
```

New way sends obj that includes the urls and the list of subscriptions that match:
```js
{
  subscriptions: [
    { name: 'aaaaa', uuid: 'a07803dc-5899-4d74-951d-963780ef27a2' }
  ],
  urls: [ 'api/v1/channels/bbbbb/1c9a1e5b-742c-40a2-bdd8-3773a9711f18' ]
}
```