### PR TITLE
Breaking: Razeedeploy delta job (fixes razeedeploy-delta #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,23 @@ channels and subscriptions
 | RAZEE_ORG_KEY       | yes | The orgApiKey used to communicate with razeedash-api. ex: orgApiKey-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeer . You can find this value from your org page on RazeeDash. ex: https://your-razeedash/your-orgname/org|
 | RAZEE_TAGS          | yes | One or more comma-separated subscription tags which were defined in Razeedash  |
 
-These variables should be set in a config map called `clustersubscription`
+These variables should be set in a ConfigMap and Secret called `clustersubscription`
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: clustersubscription
+data:
+  RAZEE_API: "http://api-host:8081"
+  RAZEE_TAGS: "tag1, tag2"
+---
+apiVersion: v1
+kind: Secret
+metadata:
  name: clustersubscription
 data:
- RAZEE_API: "http://api-host:8081"
  RAZEE_ORG_KEY: "orgApiKey-...."
- RAZEE_TAGS: "tag1, tag2"
 ```
 
 Updates to the ConfigMap require a restart of your `clustersubscription` pod

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Subscribe to Razee controlled resources
 ie. `https://app.razee.io/stark-industries/org`
 - Install RazeeDeploy and ClusterSubscription in your cluster using the
 `Install Razee Agent` command on the org page.
-    - ie. `kubectl apply -f "https://app.razee.io/api/install/razeedeploy-job?orgKey=orgApiKey-..."`
+  - ie. `kubectl apply -f "https://app.razee.io/api/install/razeedeploy-job?orgKey=orgApiKey-..."`
 - Edit the `clustersubscription` config map on your cluster(s) to add the
 RAZEE_TAGS that you want.
-    - `kubectl edit cm clustersubscription`
-    - `RAZEE_TAGS: 'comma,separated,tags,go,here'`
+  - `kubectl edit cm clustersubscription`
+  - `RAZEE_TAGS: 'comma,separated,tags,go,here'`
 - Logon to your RazeeDash server and go to the `Deployables` page to create
 channels and subscriptions
 
@@ -44,4 +44,4 @@ data:
  RAZEE_ORG_KEY: "orgApiKey-...."
 ```
 
-Updates to the ConfigMap require a restart of your `clustersubscription` pod
+Updates to the ConfigMap and Secret require a restart of your `clustersubscription` pod

--- a/README.md
+++ b/README.md
@@ -4,25 +4,17 @@ Subscribe to Razee controlled resources
 
 ## Install
 
-- Create the `clustersubscription` config map on your cluster(s)
-
-  ```shell
-  kubectl create cm clustersubscription \
-  --from-literal=RAZEE_API=${RAZEE_API} \
-  --from-literal=RAZEE_ORG_KEY=${RAZEE_ORG_KEY} \
-  --from-literal=RAZEE_TAGS='comma-separated-tags-go-here'
-  ```
-
-- Install RazeeDeploy and ClusterSubscription in your cluster
-
-```shell
-kubectl apply -f https://github.com/razee-io/RazeeDeploy-delta/releases/latest/download/resource.yaml
-kubectl apply -f https://github.com/razee-io/ClusterSubscription/releases/latest/download/resource.yaml
-
-```
-
-- Logon to your RazeeDash server and go to the
-`Deployables` page to create channels and subscriptions
+- Logon to your RazeeDash server and go to the manage org page.
+ie. `https://app.razee.io/stark-industries/org`
+- Install RazeeDeploy and ClusterSubscription in your cluster using the
+`Install Razee Agent` command on the org page.
+    - ie. `kubectl apply -f "https://app.razee.io/api/install/razeedeploy-job?orgKey=orgApiKey-..."`
+- Edit the `clustersubscription` config map on your cluster(s) to add the
+RAZEE_TAGS that you want.
+    - `kubectl edit cm clustersubscription`
+    - `RAZEE_TAGS: 'comma,separated,tags,go,here'`
+- Logon to your RazeeDash server and go to the `Deployables` page to create
+channels and subscriptions
 
 ## Environment Variables
 <!--Markdownlint-disable MD034-->

--- a/kubernetes/ClusterSubscription/resource.yaml
+++ b/kubernetes/ClusterSubscription/resource.yaml
@@ -39,15 +39,15 @@ spec:
                 fieldPath: metadata.namespace
           - name: RAZEE_ORG_KEY
             valueFrom:
-              configMapKeyRef:
+              secretKeyRef:
                 name: clustersubscription
                 key: RAZEE_ORG_KEY
-          - name: RAZEE_TAGS 
+          - name: RAZEE_TAGS
             valueFrom:
               configMapKeyRef:
                 name: clustersubscription
                 key: RAZEE_TAGS
-          - name: RAZEE_API 
+          - name: RAZEE_API
             valueFrom:
               configMapKeyRef:
                 name: clustersubscription

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ if (!RAZEE_API) {
 const regex = /\/*$/gi;
 const API_HOST = RAZEE_API.replace(regex, '');
 
-const API_VERSION = 'deploy.razee.io/v1alpha1';
+const API_VERSION = 'deploy.razee.io/v1alpha2';
 const KIND = 'RemoteResource';
 const RESOURCE_NAME = 'clustersubscription-rr';
 const NAMESPACE = process.env.NAMESPACE;


### PR DESCRIPTION
moves RAZEE_ORG_KEY to a secret and updates the README.md for new install instructions