### PR TITLE
feat: define impersonateUser for generated remoteresources

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -49,6 +49,7 @@ const getSubscriptionsByCluster = async (razeeApi, apiKey, clusterId) => {
             subscriptionName
             subscriptionUuid
             url
+            kubeOwnerName
           }
         }
       `,

--- a/lib/remoteResource.js
+++ b/lib/remoteResource.js
@@ -36,14 +36,14 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
           'name': resourceName,
           'annotations': {
             'deploy.razee.io/clustersubscription': sub.subscriptionUuid,
-            'deploy.razee.io/clusterid': clusterId,
+            'deploy.razee.io/clusterid': clusterId
           },
           'labels': {
             'razee/watch-resource': 'lite'
           }
         },
         'spec': {
-          'requests': [],
+          'requests': []
         }
       };
       if(sub.kubeOwnerName){

--- a/lib/remoteResource.js
+++ b/lib/remoteResource.js
@@ -20,10 +20,10 @@ const requestsTemplate = `{
 }`;
 
 const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId) => {
-  log.info('create remote resources subscription list', {subscriptions} );
+  log.info('create remote resources subscription list', { subscriptions });
   try {
     const krm = await kc.getKubeResourceMeta(API_VERSION, KIND, 'update');
-    return Promise.all(subscriptions.map( async sub => {
+    return Promise.all(subscriptions.map(async sub => {
       const url = `${razeeApi}/${sub.url}`;
       const rendered = Mustache.render(requestsTemplate, { url: url, orgKey: apiKey });
       const parsed = JSON.parse(rendered);
@@ -46,7 +46,7 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
           'requests': []
         }
       };
-      if(sub.kubeOwnerName){
+      if (sub.kubeOwnerName) {
         resourceTemplate.spec.clusterAuth = {
           impersonateUser: sub.kubeOwnerName,
         };
@@ -63,18 +63,18 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
         log.info(`Attempting mergePatch for an existing resource ${uri}`);
         const mergeResult = await krm.mergePatch(resourceName, NAMESPACE, resourceTemplate, opt);
         if (mergeResult.statusCode === 200) {
-          log.info('mergePatch successful', {'statusCode': mergeResult.statusCode, 'statusMessage': mergeResult.statusMessage});
+          log.info('mergePatch successful', { 'statusCode': mergeResult.statusCode, 'statusMessage': mergeResult.statusMessage });
         } else {
-          log.error('mergePatch error', {'statusCode': mergeResult.statusCode, 'statusMessage': mergeResult.statusMessage});
+          log.error('mergePatch error', { 'statusCode': mergeResult.statusCode, 'statusMessage': mergeResult.statusMessage });
         }
       } else if (get.statusCode === 404) {
         // the remote resource does not exist so use post to apply the resource
         log.info(`Attempting post for a new resource ${uri}`);
         const postResult = await krm.post(resourceTemplate, opt);
         if (postResult.statusCode === 200 || postResult.statusCode === 201) {
-          log.info('post successful', {'statusCode': postResult.statusCode, 'statusMessage': postResult.statusMessage});
+          log.info('post successful', { 'statusCode': postResult.statusCode, 'statusMessage': postResult.statusMessage });
         } else {
-          log.error('post error', {'statusCode': postResult.statusCode, 'statusMessage': postResult.statusMessage});
+          log.error('post error', { 'statusCode': postResult.statusCode, 'statusMessage': postResult.statusMessage });
         }
       } else {
         log.error(`Get ${get.statusCode} ${uri}`);
@@ -82,7 +82,7 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
     }));
 
   } catch (error) {
-    log.error('There was an error creating remote resources', {error});
+    log.error('There was an error creating remote resources', { error });
   }
 
 };
@@ -118,12 +118,12 @@ const getRemoteResources = async (clusterId) => {
     const krm = await kc.getKubeResourceMeta(API_VERSION, KIND, 'get');
     const opt = { simple: false, resolveWithFullResponse: true };
     const get = await krm.get('', NAMESPACE, opt);
-    if(get.statusCode === 200) {
-      remoteResources = get.body.items.filter( (item) => {
-        if(item.metadata.annotations && item.metadata.annotations['deploy.razee.io/clustersubscription'] ) {
-          log.debug('existing remote-resource', {name: item.metadata.name}, {annotation: item.metadata.annotations['deploy.razee.io/clustersubscription']});
-          if(item.metadata.annotations['deploy.razee.io/clusterid']) {
-            if(item.metadata.annotations['deploy.razee.io/clusterid'] === clusterId) {
+    if (get.statusCode === 200) {
+      remoteResources = get.body.items.filter((item) => {
+        if (item.metadata.annotations && item.metadata.annotations['deploy.razee.io/clustersubscription']) {
+          log.debug('existing remote-resource', { name: item.metadata.name }, { annotation: item.metadata.annotations['deploy.razee.io/clustersubscription'] });
+          if (item.metadata.annotations['deploy.razee.io/clusterid']) {
+            if (item.metadata.annotations['deploy.razee.io/clusterid'] === clusterId) {
               return item.metadata.annotations['deploy.razee.io/clustersubscription'];
             }
           } else {

--- a/lib/remoteResource.js
+++ b/lib/remoteResource.js
@@ -28,7 +28,7 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
       const rendered = Mustache.render(requestsTemplate, { url: url, orgKey: apiKey });
       const parsed = JSON.parse(rendered);
       const resourceName = `clustersubscription-${sub.subscriptionUuid}`;
-      const impersonateUser = (sub.kubeOwnerName && typeof sub.kubeOwnerName === 'string') ? sub.kubeOwnerName : 'razeedeploy';
+      const userName = (sub.kubeOwnerName && typeof sub.kubeOwnerName === 'string') ? sub.kubeOwnerName : 'razeedeploy';
       const resourceTemplate = {
         'apiVersion': API_VERSION,
         'kind': KIND,
@@ -45,7 +45,7 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
         },
         'spec': {
           'clusterAuth': {
-            'impersonateUser': impersonateUser
+            'impersonateUser': userName
           },
           'requests': []
         }

--- a/lib/remoteResource.js
+++ b/lib/remoteResource.js
@@ -28,6 +28,7 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
       const rendered = Mustache.render(requestsTemplate, { url: url, orgKey: apiKey });
       const parsed = JSON.parse(rendered);
       const resourceName = `clustersubscription-${sub.subscriptionUuid}`;
+      const impersonateUser = (sub.kubeOwnerName && typeof sub.kubeOwnerName === 'string') ? sub.kubeOwnerName : 'razeedeploy';
       const resourceTemplate = {
         'apiVersion': API_VERSION,
         'kind': KIND,
@@ -43,14 +44,12 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
           }
         },
         'spec': {
+          'clusterAuth': {
+            'impersonateUser': impersonateUser
+          },
           'requests': []
         }
       };
-      if (sub.kubeOwnerName) {
-        resourceTemplate.spec.clusterAuth = {
-          impersonateUser: sub.kubeOwnerName,
-        };
-      }
       resourceTemplate.spec.requests.push(parsed);
 
       const opt = { simple: false, resolveWithFullResponse: true };

--- a/lib/remoteResource.js
+++ b/lib/remoteResource.js
@@ -18,7 +18,7 @@ const requestsTemplate = `{
     }
   }
 }`;
-  
+
 const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId) => {
   log.info('create remote resources subscription list', {subscriptions} );
   try {
@@ -36,16 +36,21 @@ const createRemoteResources = async (razeeApi, apiKey, subscriptions, clusterId)
           'name': resourceName,
           'annotations': {
             'deploy.razee.io/clustersubscription': sub.subscriptionUuid,
-            'deploy.razee.io/clusterid': clusterId
+            'deploy.razee.io/clusterid': clusterId,
           },
           'labels': {
             'razee/watch-resource': 'lite'
           }
         },
         'spec': {
-          'requests': []
+          'requests': [],
         }
       };
+      if(sub.kubeOwnerName){
+        resourceTemplate.spec.clusterAuth = {
+          impersonateUser: sub.kubeOwnerName,
+        };
+      }
       resourceTemplate.spec.requests.push(parsed);
 
       const opt = { simple: false, resolveWithFullResponse: true };
@@ -123,8 +128,8 @@ const getRemoteResources = async (clusterId) => {
             }
           } else {
             return item.metadata.annotations['deploy.razee.io/clustersubscription'];
-          } 
-        } 
+          }
+        }
       });
     }
   } catch (error) {


### PR DESCRIPTION
Sends a `resourceTemplate.spec.clusterAuth.impersonateUser` attr if the sub contains a `kubeOwnerName` value