### PR TITLE
adds env variable RAZEE_UPDATE_INTERVAL_MS for razee update interval customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Cluster Groups, Channels and Subscriptions
 | RAZEE_API                | yes | The url to your razeedash-api. ex: http://api-host:8081  Found in the `razee-identidy` ConfigMap|
 | RAZEE_ORG_KEY            | yes | The orgApiKey used to communicate with razeedash-api. ex: orgApiKey-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeer . Found in the `razee-identity` Secret|
 | CLUSTER_ID               | yes | The razee defined cluster id.  Found in the `razee-identity` ConfigMap|
-| RAZEE_UPDATE_INTERVAL_MS | no  | (Optional) The razee defined update interval in ms and should be larger than 60000.  Found in the `razee-identity` ConfigMap|
+| RAZEE_UPDATE_INTERVAL_MS | no  | (Optional) The razee defined update interval in ms and should be larger than 60000.  Found in the `clustersubscription-overrides` ConfigMap|
 
 ### Upgrading to 3.0
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Cluster Groups, Channels and Subscriptions
 <!--Markdownlint-disable MD013-->
 | Name | Required | Description |
 | ---- | -------- | ------------- |
-| RAZEE_API           | yes | The url to your razeedash-api. ex: http://api-host:8081  Found in the `razee-identidy` ConfigMap|
-| RAZEE_ORG_KEY       | yes | The orgApiKey used to communicate with razeedash-api. ex: orgApiKey-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeer . Found in the `razee-identity` Secret|
-| CLUSTER_ID          | yes | The razee defined cluster id.  Found in the `razee-identity` ConfigMap|
+| RAZEE_API                | yes | The url to your razeedash-api. ex: http://api-host:8081  Found in the `razee-identidy` ConfigMap|
+| RAZEE_ORG_KEY            | yes | The orgApiKey used to communicate with razeedash-api. ex: orgApiKey-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeer . Found in the `razee-identity` Secret|
+| CLUSTER_ID               | yes | The razee defined cluster id.  Found in the `razee-identity` ConfigMap|
+| RAZEE_UPDATE_INTERVAL_MS | no  | (Optional) The razee defined update interval in ms and should be larger than 60000.  Found in the `razee-identity` ConfigMap|
 
 ### Upgrading to 3.0
 

--- a/kubernetes/ClusterSubscription/resource.yaml
+++ b/kubernetes/ClusterSubscription/resource.yaml
@@ -69,5 +69,11 @@ spec:
                 configMapKeyRef:
                   name: razee-identity
                   key: CLUSTER_ID
+            - name: RAZEE_UPDATE_INTERVAL_MS
+                valueFrom:
+                  configMapKeyRef:
+                    name: razee-identity
+                    key: RAZEE_UPDATE_INTERVAL_MS
+                    optional: true
           imagePullPolicy: Always
           name: clustersubscription

--- a/kubernetes/ClusterSubscription/resource.yaml
+++ b/kubernetes/ClusterSubscription/resource.yaml
@@ -72,7 +72,7 @@ spec:
             - name: RAZEE_UPDATE_INTERVAL_MS
                 valueFrom:
                   configMapKeyRef:
-                    name: razee-identity
+                    name: clustersubscription-overrides
                     key: RAZEE_UPDATE_INTERVAL_MS
                     optional: true
           imagePullPolicy: Always

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ function main() {
     throw 'Please specify process.env.CLUSTER_ID';
   }
   if (razeeUpdateInterval < 60000) {
-    throw 'Please use a value greater than 60000';
+    throw `Please use a value greater than or equal to 60000. RAZEE_UPDATE_INTERVAL_MS=${RAZEE_UPDATE_INTERVAL_MS}`;
   }
   log.debug({ razeeApi, clusterId, razeeUpdateInterval });
 


### PR DESCRIPTION
### What has been done?
- Adds a new environment variable to modify the interval the rate `razee` updates 
   - uses the environment variable: `RAZEE_UPDATE_INTERVAL_MS` and is optional.  Defaults to `300000` (the original value at 5 mins)
   - currently set to have the lowest interval update time of `60000` (1 minute) or will error out if given a value lower.
   - Follows the same mechanisms as the other environment variables.