### PR TITLE
Read razee-identity secret via kube api

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -23,6 +23,7 @@
         "notes": "The Request package (see above) requires tough-cookie at a vulnerable version.",
         "expiry": "2024-02-30"
       }
-    }    ],
+    }
+  ],
   "skip-dev": true
 }

--- a/kubernetes/ClusterSubscription/resource.yaml
+++ b/kubernetes/ClusterSubscription/resource.yaml
@@ -59,16 +59,9 @@ spec:
           volumeMounts:
             - name: razee-identity-config
               mountPath: /home/node/envs/razee-identity-config
-            - name: razee-identity-secret
-              mountPath: /home/node/envs/razee-identity-secret
       volumes:
         - name: razee-identity-config
           configMap:
             name: razee-identity
-            defaultMode: 0400
-            optional: true
-        - name: razee-identity-secret
-          secret:
-            secretName: razee-identity
             defaultMode: 0400
             optional: true

--- a/src/Config.js
+++ b/src/Config.js
@@ -19,11 +19,9 @@ const chokidar = require('chokidar');
 
 module.exports = class Config {
   static razeeApiPath = 'envs/razee-identity-config/RAZEE_API';
-  static orgKeyPath = 'envs/razee-identity-secret/RAZEE_ORG_KEY';
   static clusterIdPath = 'envs/razee-identity-config/CLUSTER_ID';
 
   static razeeApi = process.env.RAZEE_API;
-  static orgKey = process.env.RAZEE_ORG_KEY;
   static clusterId = process.env.CLUSTER_ID;
 
   static watcher;
@@ -31,12 +29,6 @@ module.exports = class Config {
   static async readRazeeApi() {
     if (await fs.pathExists(this.razeeApiPath)) {
       this.razeeApi = ((await fs.readFile(this.razeeApiPath, 'utf8')).trim() || this.razeeApi);
-    }
-  }
-
-  static async readOrgKey() {
-    if (await fs.pathExists(this.orgKeyPath)) {
-      this.orgKey = ((await fs.readFile(this.orgKeyPath, 'utf8')).trim() || this.orgKey);
     }
   }
 
@@ -48,7 +40,6 @@ module.exports = class Config {
 
   static async init() {
     await this.readRazeeApi();
-    await this.readOrgKey();
     await this.readClusterId();
   }
 
@@ -57,10 +48,6 @@ module.exports = class Config {
       if (event === 'add' || event === 'change') {
         if (path === this.razeeApiPath) {
           this.readRazeeApi();
-        }
-
-        if (path === this.orgKeyPath) {
-          this.readOrgKey();
         }
 
         if (path === this.clusterIdPath) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,14 +12,14 @@ const kc = new KubeClass();
 // Read from razee-identity secret dynamically (rather than mounting as a volume and reading from a file) to satisfy scenarios where this operator is run on a separate cluster
 const getOrgKey = async () => {
   const krm = await kc.getKubeResourceMeta('v1', 'Secret', 'get');
-  const res = await krm.request({ uri: `/api/v1/namespaces/razeedeploy/secrets/razee-identity`, json: true });
+  const res = await krm.request({ uri: '/api/v1/namespaces/razeedeploy/secrets/razee-identity', json: true });
   let base64KeyData = objectPath.get(res, ['data', 'RAZEE_ORG_KEY']);
   if (base64KeyData === undefined) {
-    throw new Error(`razeedeploy/razee-identity secret does not contain RAZEE_ORG_KEY`);
+    throw new Error('razeedeploy/razee-identity secret does not contain RAZEE_ORG_KEY');
   }
   let secret = Buffer.from(base64KeyData, 'base64');
   return secret.toString();
-}
+};
 
 const razeeListener = async (razeeApi, clusterId) => {
   webSocketClient(razeeApi).subscribe((event) => {
@@ -41,7 +41,7 @@ const callRazee = async (razeeApi, clusterId) => {
   }
   catch(e) {
     log.info(`RAZEE_ORG_KEY could not be read from the razeedeploy/razee-identity secret (falling back to env var): ${e.message}`);
-    orgKey = process.env.RAZEE_ORG_KEY
+    orgKey = process.env.RAZEE_ORG_KEY;
   }
   if (!orgKey) {
     throw 'RAZEE_ORG_KEY is missing';


### PR DESCRIPTION
Read razee-identity secret via kube api to enable scenarios where the operator is run from a separate kube cluster but with config allowing it to call the kube api of the managed cluster.